### PR TITLE
fix: Nixpacksのパッケージ名を修正

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["...", "libnss3", "libatk-bridge-2.0", "libdrm", "libxkbcommon", "libgtk-3.0"]
+nixPkgs = ["...", "libnss3", "at-spi2-atk", "libdrm", "libxkbcommon", "gtk3", "alsa-lib"]
 
 [phases.install]
 cmds = ["npm ci --include=dev"]


### PR DESCRIPTION
- libatk-bridge-2.0 → at-spi2-atk
- libgtk-3.0 → gtk3
- alsa-libを追加（音声関連の依存関係）

